### PR TITLE
Fix warning by adding JANET_ATEND

### DIFF
--- a/src/mod.c
+++ b/src/mod.c
@@ -8,13 +8,7 @@
 
 static const JanetAbstractType tb_event_jt = {
     "event",
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL
+    JANET_ATEND_NAME
 };
 
 /********************/


### PR DESCRIPTION
This change silences warning in the latest Janet versions.